### PR TITLE
Update to work with rikolti changes

### DIFF
--- a/loris2.py
+++ b/loris2.py
@@ -126,6 +126,8 @@ def wrapped_get_info(request, ident, base_uri):
 
 # complete the monkey patch
 application.route = new_route
+# NOTE: this get_info monkey patch causes every other request to the same info.json
+# URL to return a 500. This is what's been happening in production for years though...
 application.get_info = wrapped_get_info
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pillow>=6.2.0
+pillow==9.5.0
 werkzeug==2.0.3
 boto3==1.12.7
 botocore==1.15.7


### PR DESCRIPTION
I'm deploying this to the `eb-dsc-potto-loris-env` beanstalk in the pad-prd account. We can wait to merge this into master until we've cut over fully to rikolti? I guess otoh it probably doesn't hurt to do it now.

This PR updates the resolver to expect "iiif/{collection_id}/filename" in the URL. This is related to 2 changes:
1. We added the potto-loris beanstalk to the main calisphere cloudfront as an origin, with associated behavior on path = "/iiif/*"
2. We are now storing jp2000s on s3 with collection_id in the prefix

It also makes the following change: we use `urllib.parse.unquote_plus` instead of `urllib.parse.unquote` to decode the identifier before using as an S3 key, as S3 keys can and do contain spaces.